### PR TITLE
Remove shebangs on non-executables

### DIFF
--- a/buttermanager/buttermanager/exception/exception.py
+++ b/buttermanager/buttermanager/exception/exception.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/filesystem/filesystem.py
+++ b/buttermanager/buttermanager/filesystem/filesystem.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/filesystem/snapshot.py
+++ b/buttermanager/buttermanager/filesystem/snapshot.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/manager/upgrader.py
+++ b/buttermanager/buttermanager/manager/upgrader.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/util/settings.py
+++ b/buttermanager/buttermanager/util/settings.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/util/utils.py
+++ b/buttermanager/buttermanager/util/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>

--- a/buttermanager/buttermanager/window/windows.py
+++ b/buttermanager/buttermanager/window/windows.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018-2019 Eloy García Almadén <eloy.garcia.pca@gmail.com>


### PR DESCRIPTION
These files are not meant to be executed, they should not have shebangs

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>