### PR TITLE
Fix test for ~/.local/share/applications and creation in installers

### DIFF
--- a/install/native_install.sh
+++ b/install/native_install.sh
@@ -46,12 +46,12 @@ if [[ "$installButterManager" == "y" ]]; then
 
     # Creating desktop launcher
     echo -e "Creating desktop launcher..."
-    if [ ! -d "~/.local/share/applications/" ] 
+    if [ ! -d "${HOME}/.local/share/applications/" ]
     then
-        echo "Directory ~/.local/share/applications/ doesn't exist. Creating it to store ButterManager desktop launcher."
-        mkdir ~/.local/share/applications/ 
+        echo "Directory ${HOME}/.local/share/applications/ doesn't exist. Creating it to store ButterManager desktop launcher."
+        mkdir -p ${HOME}/.local/share/applications/
     fi
-    cp ../packaging/buttermanager.desktop ~/.local/share/applications/
+    cp ../packaging/buttermanager.desktop ${HOME}/.local/share/applications/
 
     # Installing libraries and ButterManager natively
     echo "Installing libraries and ButterManager natively..."

--- a/install/uninstall.sh
+++ b/install/uninstall.sh
@@ -18,6 +18,6 @@ if test -f "$installed_files"; then
 fi
 
 sudo rm -rf /opt/buttermanager/
-rm ~/.local/share/applications/buttermanager.desktop
+rm ${HOME}/.local/share/applications/buttermanager.desktop
 
 echo "Uninstallation process has been successfully completed. You are good to go!"

--- a/install/venv_install.sh
+++ b/install/venv_install.sh
@@ -42,12 +42,12 @@ if [[ "$installButterManager" == "y" ]]; then
 
     # Creating desktop launcher
     echo -e "Creating desktop launcher..."
-    if [ ! -d "~/.local/share/applications/" ] 
+    if [ ! -d "${HOME}/.local/share/applications/" ]
     then
-        echo "Directory ~/.local/share/applications/ doesn't exist. Creating it to store ButterManager desktop launcher."
-        mkdir ~/.local/share/applications/ 
+        echo "Directory ${HOME}/.local/share/applications/ doesn't exist. Creating it to store ButterManager desktop launcher."
+        mkdir -p ${HOME}/.local/share/applications/
     fi
-    cp ../packaging/buttermanager_venv.desktop ~/.local/share/applications/buttermanager.desktop
+    cp ../packaging/buttermanager_venv.desktop ${HOME}/.local/share/applications/buttermanager.desktop
 
     # Creating virtual environment
     echo "Creating virtual environment..."


### PR DESCRIPTION
I changed the use of `~` for referencing the user's home directory to `${HOME}`, which fixes failing tests for the existence of `~/.local/share/applications`.

Before:

```marc@gorgak $ ./venv_install.sh 
You are about to install ButterManager in a virtual environment.
These packages MUST be installed before executing this script: 'python-setuptools', 'python-virtualenv' 
and 'tkinter'. The name of these packages can be different depending on the distro you are using. Example:
On Arch -> 'python-setuptools', 'python-virtualenv' and 'tk'. On Fedora 'python3-setuptools', 'python3-virtual
env' and 'python3-tkinter'. In addition, if you are on Ubuntu or derivative, 'libxcb-xinerama0' needs to be
installed too.
Do you want to proceed with the installation? [y/n]
y
Removing old installation...
Creating installation directory in /opt/buttermanager
Copying all the files needed into /opt/buttermanager
Creating desktop launcher...
Directory ~/.local/share/applications/ doesn't exist. Creating it to store ButterManager desktop launcher.
mkdir: cannot create directory ‘/home/marc/.local/share/applications/’: File exists
Creating virtual environment...
<cut>
```

After:
```
marc@gorgak $ ./venv_install.sh 
You are about to install ButterManager in a virtual environment.
These packages MUST be installed before executing this script: 'python-setuptools', 'python-virtualenv' and 'tkinter'. The name of these packages can be different depending on the distro you are using. Example: On Arch -> 'python-setuptools', 'python-virtualenv' and 'tk'. On Fedora 'python3-setuptools', 'python3-virtualenv' and 'python3-tkinter'. In addition, if you are on Ubuntu or derivative, 'libxcb-xinerama0' needs to be installed too.
Do you want to proceed with the installation? [y/n]
y
Removing old installation...
Creating installation directory in /opt/buttermanager
Copying all the files needed into /opt/buttermanager
Creating desktop launcher...
Creating virtual environment...
<cut>
```

